### PR TITLE
Write schema loader as class

### DIFF
--- a/browser/src/schema/init.js
+++ b/browser/src/schema/init.js
@@ -4,62 +4,7 @@
  * This file is a copy of the original `src/schema/init.js` with the import path for the schema loader modified
  * to point to the browser-specific version.
  */
-import zip from 'lodash/zip'
-
-import { loadSchema } from './loader'
-import SchemaParser from '../../../src/schema/parser'
-import PartneredSchemaMerger from '../../../src/schema/schemaMerger'
-import { Schema, HedSchemas } from '../../../src/schema/containers'
-import { IssueError } from '../../../src/issues/issues'
-import { splitStringTrimAndRemoveBlanks } from '../../../src/utils/string'
-import { SchemasSpec } from '../../../src/schema/specs'
-
-/**
- * Build a single schema container object from an XML file.
- *
- * @param {Object} xmlData The schema's XML data
- * @returns {HedSchema} The HED schema object.
- */
-const buildSchemaObject = function (xmlData) {
-  const schemaEntries = new SchemaParser(xmlData.HED).parse()
-  return new Schema(xmlData, schemaEntries)
-}
-
-/**
- * Build a single merged schema container object from one or more XML files.
- *
- * @param {Object[]} xmlData The schemas' XML data.
- * @returns {HedSchema} The HED schema object.
- */
-const buildSchemaObjects = function (xmlData) {
-  const schemas = xmlData.map((data) => buildSchemaObject(data))
-  if (schemas.length === 1) {
-    return schemas[0]
-  }
-  const partneredSchemaMerger = new PartneredSchemaMerger(schemas)
-  return partneredSchemaMerger.mergeSchemas()
-}
-
-/**
- * Build a schema collection object from a schema specification.
- *
- * @param {SchemasSpec} schemaSpecs The description of which schemas to use.
- * @returns {Promise<HedSchemas>} The schema container object and any issues found.
- */
-export async function buildSchemas(schemaSpecs) {
-  const schemaPrefixes = Array.from(schemaSpecs.data.keys())
-  /* Data format example:
-   * [[xmlData, ...], [xmlData, xmlData, ...], ...] */
-  const schemaXmlData = await Promise.all(
-    schemaPrefixes.map((prefix) => {
-      const specs = schemaSpecs.data.get(prefix)
-      return Promise.all(specs.map((spec) => loadSchema(spec)))
-    }),
-  )
-  const schemaObjects = schemaXmlData.map(buildSchemaObjects)
-  const schemas = new Map(zip(schemaPrefixes, schemaObjects))
-  return new HedSchemas(schemas)
-}
+import HedSchemaLoader from './loader'
 
 /**
  * Build HED schemas from a version specification string.
@@ -69,8 +14,5 @@ export async function buildSchemas(schemaSpecs) {
  * @throws {IssueError} If the schema specification is invalid or schemas cannot be built.
  */
 export async function buildSchemasFromVersion(hedVersionString) {
-  hedVersionString ??= ''
-  const hedVersionSpecStrings = splitStringTrimAndRemoveBlanks(hedVersionString, ',')
-  const hedVersionSpecs = SchemasSpec.parseVersionSpecs(hedVersionSpecStrings)
-  return buildSchemas(hedVersionSpecs)
+  return new HedSchemaLoader().buildSchemasFromVersion(hedVersionString)
 }

--- a/browser/src/schema/loader.js
+++ b/browser/src/schema/loader.js
@@ -3,7 +3,7 @@
 /* Imports */
 import { schemaData } from './vite-importer'
 import { IssueError } from '../../../src/issues/issues'
-import AbstractHedSchemaLoader from '../../../src/schema/abstractLoader.js'
+import AbstractHedSchemaLoader from '../../../src/schema/abstractLoader'
 
 export default class HedSchemaLoader extends AbstractHedSchemaLoader {
   /**
@@ -46,7 +46,7 @@ export default class HedSchemaLoader extends AbstractHedSchemaLoader {
     const schemaLoader = schemaData[localPath]
     if (!schemaLoader) {
       // We've already verified this exists, so this is a consistency error.
-      IssueError.generateAndThrowInternalError('Schema loader has disappeared after already being checked.')
+      IssueError.generateAndThrowInternalError('Schema loader has disappeared after already being checked')
     }
     return await schemaLoader()
   }

--- a/browser/src/schema/loader.js
+++ b/browser/src/schema/loader.js
@@ -1,114 +1,50 @@
 /** HED schema loading functions. */
 
 /* Imports */
-import { IssueError } from '../../../src/issues/issues'
-import parseSchemaXML from '../../../src/utils/xml.js'
 import { schemaData } from './vite-importer'
+import { IssueError } from '../../../src/issues/issues'
+import AbstractHedSchemaLoader from '../../../src/schema/abstractLoader.js'
 
-/**
- * Load schema XML data from a schema version or path description.
- *
- * @param {SchemaSpec} schemaDef The description of which schema to use.
- * @returns {Promise<object>} The schema XML data.
- * @throws {IssueError} If the schema could not be loaded.
- */
-export async function loadSchema(schemaDef = null) {
-  const xmlData = await loadPromise(schemaDef)
-  if (xmlData === null) {
-    IssueError.generateAndThrow('invalidSchemaSpecification', { spec: JSON.stringify(schemaDef) })
+export default class HedSchemaLoader extends AbstractHedSchemaLoader {
+  /**
+   * Load schema XML data from a local file.
+   *
+   * @param {string} path - The path to the schema XML data.
+   * @returns {Promise<never>} The schema XML data.
+   * @throws {IssueError} If the schema could not be loaded.
+   */
+  async loadLocalSchema(path) {
+    IssueError.generateAndThrow('localSchemaLoadFailed', {
+      path,
+      error: 'Local schema loading is not supported in the browser.',
+    })
   }
-  return xmlData
-}
 
-/**
- * Choose the schema Promise from a schema version or path description.
- *
- * @param {SchemaSpec} schemaDef The description of which schema to use.
- * @returns {Promise<object>} The schema XML data.
- * @throws {IssueError} If the schema could not be loaded.
- */
-async function loadPromise(schemaDef) {
-  if (schemaDef === null) {
-    return null
-  } else if (schemaDef.localPath) {
-    return loadLocalSchema(schemaDef.localPath)
-  } else if (schemaDef.localName) {
-    return loadBundledSchema(schemaDef)
-  } else {
-    return loadRemoteSchema(schemaDef)
+  /**
+   * Retrieve the contents of a bundled schema.
+   *
+   * @param {SchemaSpec} schemaDef - The description of which schema to use.
+   * @returns {Promise<string>} The raw schema XML data.
+   * @throws {IssueError} If the schema could not be loaded.
+   */
+  async getBundledSchema(schemaDef) {
+    const localPath = `../../../src/data/schemas/${schemaDef.localName}.xml`
+    const schemaLoader = schemaData[localPath]
+    if (!schemaLoader) {
+      // We've already verified this exists, so this is a consistency error.
+      IssueError.generateAndThrowInternalError('Schema loader has disappeared after already being checked.')
+    }
+    return await schemaLoader()
   }
-}
 
-/**
- * Load schema XML data from the HED GitHub repository.
- *
- * @param {SchemaSpec} schemaDef The standard schema version to load.
- * @returns {Promise<object>} The schema XML data.
- * @throws {IssueError} If the schema could not be loaded.
- */
-function loadRemoteSchema(schemaDef) {
-  let url
-  if (schemaDef.library) {
-    url = `https://raw.githubusercontent.com/hed-standard/hed-schemas/refs/heads/main/library_schemas/${schemaDef.library}/hedxml/HED_${schemaDef.library}_${schemaDef.version}.xml`
-  } else {
-    url = `https://raw.githubusercontent.com/hed-standard/hed-schemas/refs/heads/main/standard_schema/hedxml/HED${schemaDef.version}.xml`
-  }
-  return loadSchemaFile(
-    fetch(url).then((res) => res.text()),
-    'remoteSchemaLoadFailed',
-    { spec: JSON.stringify(schemaDef) },
-  )
-}
-
-/**
- * Load schema XML data from a local file.
- *
- * @param {string} path The path to the schema XML data.
- * @returns {Promise<object>} The schema XML data.
- * @throws {IssueError} If the schema could not be loaded.
- */
-function loadLocalSchema(path) {
-  throw new Error('Local schema loading is not supported in the browser.')
-}
-
-/**
- * Load schema XML data from a bundled file.
- *
- * @param {SchemaSpec} schemaDef The description of which schema to use.
- * @returns {Promise<object>} The schema XML data.
- * @throws {IssueError} If the schema could not be loaded.
- */
-async function loadBundledSchema(schemaDef) {
-  const localPath = `../../../src/data/schemas/${schemaDef.localName}.xml`
-  const schemaLoader = schemaData[localPath]
-  if (!schemaLoader) {
-    // This occurs in the test environment or if the schema is not found.
-    return
-  }
-  try {
-    const data = await schemaLoader()
-    return parseSchemaXML(data)
-  } catch (error) {
-    const issueArgs = { spec: JSON.stringify(schemaDef), error: error.message }
-    IssueError.generateAndThrow('bundledSchemaLoadFailed', issueArgs)
-  }
-}
-
-/**
- * Actually load the schema XML file.
- *
- * @param {Promise<string>} xmlDataPromise The Promise containing the unparsed XML data.
- * @param {string} issueCode The issue code.
- * @param {Object<string, string>} issueArgs The issue arguments passed from the calling function.
- *returns {Promise<object>} The parsed schema XML data.
- * @throws {IssueError} If the schema could not be loaded.
- */
-async function loadSchemaFile(xmlDataPromise, issueCode, issueArgs) {
-  try {
-    const data = await xmlDataPromise
-    return parseSchemaXML(data)
-  } catch (error) {
-    issueArgs.error = error.message
-    IssueError.generateAndThrow(issueCode, issueArgs)
+  /**
+   * Determine whether this validator bundles a particular schema.
+   *
+   * @param {SchemaSpec} schemaDef - The description of which schema to use.
+   * @returns {boolean} Whether this validator bundles a particular schema.
+   */
+  hasBundledSchema(schemaDef) {
+    const localPath = `../../../src/data/schemas/${schemaDef.localName}.xml`
+    return localPath in schemaData
   }
 }

--- a/browser/src/schema/loader.js
+++ b/browser/src/schema/loader.js
@@ -12,6 +12,7 @@ export default class HedSchemaLoader extends AbstractHedSchemaLoader {
    * @param {string} path - The path to the schema XML data.
    * @returns {Promise<never>} The schema XML data.
    * @throws {IssueError} If the schema could not be loaded.
+   * @override
    */
   async loadLocalSchema(path) {
     IssueError.generateAndThrow('localSchemaLoadFailed', {
@@ -21,11 +22,24 @@ export default class HedSchemaLoader extends AbstractHedSchemaLoader {
   }
 
   /**
+   * Determine whether this validator bundles a particular schema.
+   *
+   * @param {SchemaSpec} schemaDef - The description of which schema to use.
+   * @returns {boolean} Whether this validator bundles a particular schema.
+   * @override
+   */
+  hasBundledSchema(schemaDef) {
+    const localPath = `../../../src/data/schemas/${schemaDef.localName}.xml`
+    return localPath in schemaData
+  }
+
+  /**
    * Retrieve the contents of a bundled schema.
    *
    * @param {SchemaSpec} schemaDef - The description of which schema to use.
    * @returns {Promise<string>} The raw schema XML data.
    * @throws {IssueError} If the schema could not be loaded.
+   * @override
    */
   async getBundledSchema(schemaDef) {
     const localPath = `../../../src/data/schemas/${schemaDef.localName}.xml`
@@ -36,15 +50,17 @@ export default class HedSchemaLoader extends AbstractHedSchemaLoader {
     }
     return await schemaLoader()
   }
+}
 
-  /**
-   * Determine whether this validator bundles a particular schema.
-   *
-   * @param {SchemaSpec} schemaDef - The description of which schema to use.
-   * @returns {boolean} Whether this validator bundles a particular schema.
-   */
-  hasBundledSchema(schemaDef) {
-    const localPath = `../../../src/data/schemas/${schemaDef.localName}.xml`
-    return localPath in schemaData
-  }
+/**
+ * Load schema XML data from a schema version or path description.
+ *
+ * @deprecated
+ *
+ * @param {SchemaSpec} schemaDef The description of which schema to use.
+ * @returns {Promise<object>} The schema XML data.
+ * @throws {IssueError} If the schema could not be loaded.
+ */
+export async function loadSchema(schemaDef = null) {
+  return new HedSchemaLoader().loadSchema(schemaDef)
 }

--- a/browser/src/schema/loader.spec.js
+++ b/browser/src/schema/loader.spec.js
@@ -1,14 +1,24 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { loadSchema } from './loader'
 import { SchemaSpec } from '../../../src/schema/specs.ts'
 
+vi.mock(import('./vite-importer.js'), () => {
+  return {
+    schemaData: {
+      '../../../src/data/schemas/HED_HED8.0.0_8.0.0.xml': () => Promise.resolve(
+        '<?xml version="1.0" ?>\n' +
+        '<HED><schema></schema></HED>\n'
+      ),
+    }
+  }
+})
+
 describe('Browser Schema Loader', () => {
-  it('should return undefined when loading a bundled schema in test environment', async () => {
+  it('should return a parsed XML object when loading a dummy bundled schema in test environment', async () => {
     // Create a spec with localName to trigger bundled schema loading
     const spec = new SchemaSpec('', '8.0.0', 'HED8.0.0', '')
-    // In a test environment, this will return undefined since schemaData is empty
     const schema = await loadSchema(spec)
-    expect(schema).toBeUndefined()
+    expect(schema).toHaveProperty('HED')
   })
 
   it('should throw an error for local file loading', async () => {

--- a/browser/src/schema/loader.spec.js
+++ b/browser/src/schema/loader.spec.js
@@ -5,11 +5,9 @@ import { SchemaSpec } from '../../../src/schema/specs.ts'
 vi.mock(import('./vite-importer.js'), () => {
   return {
     schemaData: {
-      '../../../src/data/schemas/HED_HED8.0.0_8.0.0.xml': () => Promise.resolve(
-        '<?xml version="1.0" ?>\n' +
-        '<HED><schema></schema></HED>\n'
-      ),
-    }
+      '../../../src/data/schemas/HED_HED8.0.0_8.0.0.xml': () =>
+        Promise.resolve('<?xml version="1.0" ?>\n<HED><schema></schema></HED>\n'),
+    },
   }
 })
 

--- a/src/issues/issues.ts
+++ b/src/issues/issues.ts
@@ -58,15 +58,15 @@ export class IssueError extends Error {
   }
 
   /**
-   * Generate and re-throw an error according to {@code generateFn}.
+   * Generate and re-throw an error according to `generateFn`.
    *
    * @remarks
-   * This method will pass {@code error} to {@code generateFn}, unless it is not an {@link Error} object (in which case,
-   * it will generate an internal error via {@link IssueError.generateAndThrowInternalError}). {@code generateFn} is
+   * This method will pass `error` to `generateFn`, unless it is not an {@link Error} object (in which case,
+   * it will generate an internal error via {@link IssueError.generateAndThrowInternalError}). generateFn` is
    * expected to return an internal issue code and parameter object, which will be passed to
    * {@link IssueError.generateAndThrow}. Failure to provide an internal issue code will also result in an internal error.
    *
-   * @param error This is expected to be an object of {@code Error} or a subclass.
+   * @param error This is expected to be an object of {@link Error} or a subclass.
    * @param generateFn A function which is passed the screened error object and returns an internal error code and parameter object.
    * @param illegalErrorTypeMessage A message to be used for an illegal error type.
    */

--- a/src/schema/abstractLoader.ts
+++ b/src/schema/abstractLoader.ts
@@ -34,7 +34,7 @@ export default abstract class AbstractHedSchemaLoader {
       }),
     )
     const schemaObjects = schemaXmlData.map((schemaXmls) => this.buildSchemaObjects(schemaXmls))
-    const schemas = new Map(zip(schemaPrefixes, schemaObjects))
+    const schemas = new Map<string, HedSchema>(zip<string, HedSchema>(schemaPrefixes, schemaObjects))
     return new HedSchemas(schemas)
   }
 

--- a/src/schema/abstractLoader.ts
+++ b/src/schema/abstractLoader.ts
@@ -84,8 +84,9 @@ export default abstract class AbstractHedSchemaLoader {
    * @param schemaDef - The description of which schema to use.
    * @returns The schema XML data.
    * @throws {IssueError} If the schema could not be loaded.
+   * @internal
    */
-  private async loadSchema(schemaDef: SchemaSpec): Promise<HedSchemaXMLObject> {
+  public async loadSchema(schemaDef: SchemaSpec): Promise<HedSchemaXMLObject> {
     const xmlData = await this.loadPromise(schemaDef)
     if (xmlData === null) {
       IssueError.generateAndThrow('invalidSchemaSpecification', { spec: JSON.stringify(schemaDef) })
@@ -131,15 +132,6 @@ export default abstract class AbstractHedSchemaLoader {
   }
 
   /**
-   * Retrieve the contents of a bundled schema.
-   *
-   * @param schemaDef - The description of which schema to use.
-   * @returns The raw schema XML data.
-   * @throws {IssueError} If the schema could not be loaded.
-   */
-  protected abstract getBundledSchema(schemaDef: SchemaSpec): Promise<string>
-
-  /**
    * Determine whether this validator bundles a particular schema.
    *
    * @param schemaDef - The description of which schema to use.
@@ -147,6 +139,15 @@ export default abstract class AbstractHedSchemaLoader {
    * @throws {IssueError} If the schema could not be loaded.
    */
   protected abstract hasBundledSchema(schemaDef: SchemaSpec): boolean
+
+  /**
+   * Retrieve the contents of a bundled schema.
+   *
+   * @param schemaDef - The description of which schema to use.
+   * @returns The raw schema XML data.
+   * @throws {IssueError} If the schema could not be loaded.
+   */
+  protected abstract getBundledSchema(schemaDef: SchemaSpec): Promise<string>
 
   /**
    * Load schema XML data from the HED GitHub repository.

--- a/src/schema/abstractLoader.ts
+++ b/src/schema/abstractLoader.ts
@@ -1,0 +1,201 @@
+/**
+ * This module holds the abstract superclass for a schema loader.
+ * @module schema/abstractLoader
+ */
+
+import zip from 'lodash/zip'
+
+import { HedSchema, PrimarySchema, HedSchemas } from './containers'
+import SchemaParser from './parser'
+import PartneredSchemaMerger from './schemaMerger'
+import { type SchemaSpec, SchemasSpec } from './specs'
+import { type HedSchemaXMLObject } from './xmlType'
+import { IssueError, type IssueParameters } from '../issues/issues'
+import * as files from '../utils/files'
+import { splitStringTrimAndRemoveBlanks } from '../utils/string'
+import parseSchemaXML from '../utils/xml'
+
+export default abstract class AbstractHedSchemaLoader {
+  /**
+   * Build a schema collection object from a schema specification.
+   *
+   * @param schemaSpecs - The description of which schemas to use.
+   * @returns The schema container object and any issues found.
+   * @throws {IssueError} If the schema specification is invalid or schemas cannot be built.
+   */
+  public async buildSchemas(schemaSpecs: SchemasSpec): Promise<HedSchemas> {
+    const schemaPrefixes = Array.from(schemaSpecs.data.keys())
+    /* Data format example:
+     * [[xmlData, ...], [xmlData, xmlData, ...], ...] */
+    const schemaXmlData = await Promise.all(
+      schemaPrefixes.map((prefix) => {
+        const specs = schemaSpecs.data.get(prefix)
+        return Promise.all(specs.map((spec) => this.loadSchema(spec)))
+      }),
+    )
+    const schemaObjects = schemaXmlData.map((schemaXmls) => this.buildSchemaObjects(schemaXmls))
+    const schemas = new Map(zip(schemaPrefixes, schemaObjects))
+    return new HedSchemas(schemas)
+  }
+
+  /**
+   * Build HED schemas from a version specification string.
+   *
+   * @param hedVersionString - The HED version specification string (can contain comma-separated versions).
+   * @returns A Promise that resolves to the built schemas.
+   * @throws {IssueError} If the schema specification is invalid or schemas cannot be built.
+   */
+  public async buildSchemasFromVersion(hedVersionString?: string): Promise<HedSchemas> {
+    hedVersionString ??= ''
+    const hedVersionSpecStrings = splitStringTrimAndRemoveBlanks(hedVersionString, ',')
+    const hedVersionSpecs = SchemasSpec.parseVersionSpecs(hedVersionSpecStrings)
+    return this.buildSchemas(hedVersionSpecs)
+  }
+
+  /**
+   * Build a single merged schema container object from one or more XML files.
+   *
+   * @param xmlData - The schemas' XML data.
+   * @returns The HED schema object.
+   */
+  private buildSchemaObjects(xmlData: HedSchemaXMLObject[]): HedSchema {
+    const schemas = xmlData.map((data) => this.buildSchemaObject(data))
+    if (schemas.length === 1) {
+      return schemas[0]
+    }
+    const partneredSchemaMerger = new PartneredSchemaMerger(schemas)
+    return partneredSchemaMerger.mergeSchemas()
+  }
+
+  /**
+   * Build a single schema container object from an XML file.
+   *
+   * @param xmlData - The schema's XML data.
+   * @returns The HED schema object.
+   */
+  private buildSchemaObject(xmlData: HedSchemaXMLObject): PrimarySchema {
+    const schemaEntries = new SchemaParser(xmlData.HED).parse()
+    return new PrimarySchema(xmlData, schemaEntries)
+  }
+
+  /**
+   * Load schema XML data from a schema version or path description.
+   *
+   * @param schemaDef - The description of which schema to use.
+   * @returns The schema XML data.
+   * @throws {IssueError} If the schema could not be loaded.
+   */
+  private async loadSchema(schemaDef: SchemaSpec): Promise<HedSchemaXMLObject> {
+    const xmlData = await this.loadPromise(schemaDef)
+    if (xmlData === null) {
+      IssueError.generateAndThrow('invalidSchemaSpecification', { spec: JSON.stringify(schemaDef) })
+    }
+    return xmlData
+  }
+
+  /**
+   * Choose the schema Promise from a schema version or path description.
+   *
+   * @param schemaDef - The description of which schema to use.
+   * @returns The schema XML data.
+   * @throws {IssueError} If the schema could not be loaded.
+   */
+  private async loadPromise(schemaDef: SchemaSpec): Promise<HedSchemaXMLObject> {
+    if (schemaDef.localPath) {
+      return this.loadLocalSchema(schemaDef.localPath)
+    } else if (this.hasBundledSchema(schemaDef)) {
+      return this.loadBundledSchema(schemaDef)
+    } else {
+      return this.loadRemoteSchema(schemaDef)
+    }
+  }
+
+  /**
+   * Load schema XML data from a bundled file.
+   *
+   * @param schemaDef - The description of which schema to use.
+   * @returns The schema XML data.
+   * @throws {IssueError} If the schema could not be loaded.
+   */
+  private async loadBundledSchema(schemaDef: SchemaSpec): Promise<HedSchemaXMLObject> {
+    try {
+      const bundledSchemaData = await this.getBundledSchema(schemaDef)
+      return parseSchemaXML(bundledSchemaData)
+    } catch (error) {
+      IssueError.generateAndRethrow(
+        error,
+        (error) => ['bundledSchemaLoadFailed', { spec: JSON.stringify(schemaDef), error: error.message }],
+        'Illegal error type when loading bundled schema',
+      )
+    }
+  }
+
+  /**
+   * Retrieve the contents of a bundled schema.
+   *
+   * @param schemaDef - The description of which schema to use.
+   * @returns The raw schema XML data.
+   * @throws {IssueError} If the schema could not be loaded.
+   */
+  protected abstract getBundledSchema(schemaDef: SchemaSpec): Promise<string>
+
+  /**
+   * Determine whether this validator bundles a particular schema.
+   *
+   * @param schemaDef - The description of which schema to use.
+   * @returns Whether this validator bundles a particular schema.
+   * @throws {IssueError} If the schema could not be loaded.
+   */
+  protected abstract hasBundledSchema(schemaDef: SchemaSpec): boolean
+
+  /**
+   * Load schema XML data from the HED GitHub repository.
+   *
+   * @param schemaDef - The standard schema version to load.
+   * @returns The schema XML data.
+   * @throws {IssueError} If the schema could not be loaded.
+   */
+  private async loadRemoteSchema(schemaDef: SchemaSpec): Promise<HedSchemaXMLObject> {
+    let url: string
+    if (schemaDef.library) {
+      url = `https://raw.githubusercontent.com/hed-standard/hed-schemas/refs/heads/main/library_schemas/${schemaDef.library}/hedxml/HED_${schemaDef.library}_${schemaDef.version}.xml`
+    } else {
+      url = `https://raw.githubusercontent.com/hed-standard/hed-schemas/refs/heads/main/standard_schema/hedxml/HED${schemaDef.version}.xml`
+    }
+    return this.loadSchemaFile(files.readHTTPSFile(url), 'remoteSchemaLoadFailed', { spec: JSON.stringify(schemaDef) })
+  }
+  /**
+   * Load schema XML data from a local file.
+   *
+   * @param path - The path to the schema XML data.
+   * @returns The schema XML data.
+   * @throws {IssueError} If the schema could not be loaded.
+   */
+  protected abstract loadLocalSchema(path: string): Promise<HedSchemaXMLObject>
+
+  /**
+   * Actually load the schema XML file.
+   *
+   * @param xmlDataPromise - The Promise containing the unparsed XML data.
+   * @param issueCode - The issue code.
+   * @param issueArgs - The issue arguments passed from the calling function.
+   * @returns The parsed schema XML data.
+   * @throws {IssueError} If the schema could not be loaded.
+   */
+  protected async loadSchemaFile(
+    xmlDataPromise: Promise<string>,
+    issueCode: string,
+    issueArgs: IssueParameters,
+  ): Promise<HedSchemaXMLObject> {
+    try {
+      const data = await xmlDataPromise
+      return parseSchemaXML(data)
+    } catch (error) {
+      IssueError.generateAndRethrow(
+        error,
+        (error) => [issueCode, { ...issueArgs, error: error.message }],
+        'Illegal error type when loading schema file',
+      )
+    }
+  }
+}

--- a/src/schema/config.ts
+++ b/src/schema/config.ts
@@ -1,7 +1,7 @@
 /**
  * Bundled HED schema configuration.
  * @module schema/config
- * */
+ */
 
 // This list defines the base names of HED XML schema files
 // that are considered "bundled" with the library.

--- a/src/schema/init.ts
+++ b/src/schema/init.ts
@@ -1,4 +1,5 @@
-/** This module holds the classes for initializing and building schemas.
+/**
+ * This module holds the classes for initializing and building schemas.
  * @module schema/init
  */
 

--- a/src/schema/init.ts
+++ b/src/schema/init.ts
@@ -1,75 +1,32 @@
-/**
- * This module holds the classes for initializing and building schemas.
+/** This module holds the classes for initializing and building schemas.
  * @module schema/init
  */
 
-import zip from 'lodash/zip'
-
-import loadSchema from './loader'
-import SchemaParser from './parser'
-import PartneredSchemaMerger from './schemaMerger'
-import { HedSchema, PrimarySchema, HedSchemas } from './containers'
-import { splitStringTrimAndRemoveBlanks } from '../utils/string'
-import { SchemasSpec } from './specs'
-import { type HedSchemaXMLObject } from './xmlType'
+import type { HedSchemas } from './containers'
+import HedSchemaLoader from './loader'
+import type { SchemasSpec } from './specs'
 
 /**
  * Build a schema collection object from a schema specification.
+ *
+ * @deprecated In version 5.0.1. Use {@link HedSchemaLoader.buildSchemas}.
  *
  * @param schemaSpecs - The description of which schemas to use.
  * @returns The schema container object and any issues found.
  */
 export async function buildSchemas(schemaSpecs: SchemasSpec): Promise<HedSchemas> {
-  const schemaPrefixes = Array.from(schemaSpecs.data.keys())
-  /* Data format example:
-   * [[xmlData, ...], [xmlData, xmlData, ...], ...] */
-  const schemaXmlData = await Promise.all(
-    schemaPrefixes.map((prefix) => {
-      const specs = schemaSpecs.data.get(prefix)
-      return Promise.all(specs.map((spec) => loadSchema(spec)))
-    }),
-  )
-  const schemaObjects = schemaXmlData.map(buildSchemaObjects)
-  const schemas = new Map(zip(schemaPrefixes, schemaObjects))
-  return new HedSchemas(schemas)
+  return new HedSchemaLoader().buildSchemas(schemaSpecs)
 }
 
 /**
  * Build HED schemas from a version specification string.
+ *
+ * @deprecated In version 5.0.1. Use {@link HedSchemaLoader.buildSchemasFromVersion}.
  *
  * @param hedVersionString - The HED version specification string (can contain comma-separated versions).
  * @returns A Promise that resolves to the built schemas.
  * @throws {IssueError} If the schema specification is invalid or schemas cannot be built.
  */
 export async function buildSchemasFromVersion(hedVersionString?: string): Promise<HedSchemas> {
-  hedVersionString ??= ''
-  const hedVersionSpecStrings = splitStringTrimAndRemoveBlanks(hedVersionString, ',')
-  const hedVersionSpecs = SchemasSpec.parseVersionSpecs(hedVersionSpecStrings)
-  return buildSchemas(hedVersionSpecs)
-}
-
-/**
- * Build a single merged schema container object from one or more XML files.
- *
- * @param xmlData - The schemas' XML data.
- * @returns The HED schema object.
- */
-function buildSchemaObjects(xmlData: HedSchemaXMLObject[]): HedSchema {
-  const schemas = xmlData.map((data) => buildSchemaObject(data))
-  if (schemas.length === 1) {
-    return schemas[0]
-  }
-  const partneredSchemaMerger = new PartneredSchemaMerger(schemas)
-  return partneredSchemaMerger.mergeSchemas()
-}
-
-/**
- * Build a single schema container object from an XML file.
- *
- * @param xmlData - The schema's XML data.
- * @returns The HED schema object.
- */
-function buildSchemaObject(xmlData: HedSchemaXMLObject): PrimarySchema {
-  const schemaEntries = new SchemaParser(xmlData.HED).parse()
-  return new PrimarySchema(xmlData, schemaEntries)
+  return new HedSchemaLoader().buildSchemasFromVersion(hedVersionString)
 }

--- a/src/schema/loader.ts
+++ b/src/schema/loader.ts
@@ -1,118 +1,43 @@
 /**
- * HED schema loading functions.
+ * This module holds the implementation for a non-browser schema loader.
  * @module schema/loader
  */
 
-// Imports
-import { localSchemaMap, localSchemaNames } from './config' // Changed from localSchemaList
-import { type SchemaSpec } from './specs'
-import { type HedSchemaXMLObject } from './xmlType'
-import { IssueError, type IssueParameters } from '../issues/issues'
+import AbstractHedSchemaLoader from './abstractLoader'
+import { localSchemaMap } from './config'
+import type { SchemaSpec } from './specs'
+import type { HedSchemaXMLObject } from './xmlType'
 import * as files from '../utils/files'
-import parseSchemaXML from '../utils/xml'
 
-/**
- * Load schema XML data from a schema version or path description.
- *
- * @param schemaDef - The description of which schema to use.
- * @returns The schema XML data.
- * @throws {IssueError} If the schema could not be loaded.
- */
-export default async function loadSchema(schemaDef: SchemaSpec): Promise<HedSchemaXMLObject> {
-  const xmlData = await loadPromise(schemaDef)
-  if (xmlData === null) {
-    IssueError.generateAndThrow('invalidSchemaSpecification', { spec: JSON.stringify(schemaDef) })
+export default class HedSchemaLoader extends AbstractHedSchemaLoader {
+  /**
+   * Load schema XML data from a local file.
+   *
+   * @param path - The path to the schema XML data.
+   * @returns The schema XML data.
+   * @throws {IssueError} If the schema could not be loaded.
+   */
+  override async loadLocalSchema(path: string): Promise<HedSchemaXMLObject> {
+    return this.loadSchemaFile(files.readFile(path), 'localSchemaLoadFailed', { path })
   }
-  return xmlData
-}
 
-/**
- * Choose the schema Promise from a schema version or path description.
- *
- * @param schemaDef - The description of which schema to use.
- * @returns The schema XML data.
- * @throws {IssueError} If the schema could not be loaded.
- */
-async function loadPromise(schemaDef: SchemaSpec): Promise<HedSchemaXMLObject> {
-  if (schemaDef.localPath) {
-    return loadLocalSchema(schemaDef.localPath)
-  } else if (localSchemaNames.includes(schemaDef.localName)) {
-    // Changed condition
-    return loadBundledSchema(schemaDef)
-  } else {
-    return loadRemoteSchema(schemaDef)
+  /**
+   * Retrieve the contents of a bundled schema.
+   *
+   * @param schemaDef - The description of which schema to use.
+   * @returns The raw schema XML data.
+   */
+  override async getBundledSchema(schemaDef: SchemaSpec): Promise<string> {
+    return localSchemaMap.get(schemaDef.localName)
   }
-}
 
-/**
- * Load schema XML data from the HED GitHub repository.
- *
- * @param schemaDef - The standard schema version to load.
- * @returns The schema XML data.
- * @throws {IssueError} If the schema could not be loaded.
- */
-async function loadRemoteSchema(schemaDef: SchemaSpec): Promise<HedSchemaXMLObject> {
-  let url: string
-  if (schemaDef.library) {
-    url = `https://raw.githubusercontent.com/hed-standard/hed-schemas/refs/heads/main/library_schemas/${schemaDef.library}/hedxml/HED_${schemaDef.library}_${schemaDef.version}.xml`
-  } else {
-    url = `https://raw.githubusercontent.com/hed-standard/hed-schemas/refs/heads/main/standard_schema/hedxml/HED${schemaDef.version}.xml`
-  }
-  return loadSchemaFile(files.readHTTPSFile(url), 'remoteSchemaLoadFailed', { spec: JSON.stringify(schemaDef) })
-}
-
-/**
- * Load schema XML data from a local file.
- *
- * @param path - The path to the schema XML data.
- * @returns The schema XML data.
- * @throws {IssueError} If the schema could not be loaded.
- */
-async function loadLocalSchema(path: string): Promise<HedSchemaXMLObject> {
-  return loadSchemaFile(files.readFile(path), 'localSchemaLoadFailed', { path: path })
-}
-
-/**
- * Load schema XML data from a bundled file.
- *
- * @param schemaDef - The description of which schema to use.
- * @returns The schema XML data.
- * @throws {IssueError} If the schema could not be loaded.
- */
-async function loadBundledSchema(schemaDef: SchemaSpec): Promise<HedSchemaXMLObject> {
-  try {
-    return parseSchemaXML(localSchemaMap.get(schemaDef.localName))
-  } catch (error) {
-    IssueError.generateAndRethrow(
-      error,
-      (error) => ['bundledSchemaLoadFailed', { spec: JSON.stringify(schemaDef), error: error.message }],
-      'Illegal error type when loading bundled schema',
-    )
-  }
-}
-
-/**
- * Actually load the schema XML file.
- *
- * @param xmlDataPromise - The Promise containing the unparsed XML data.
- * @param issueCode - The issue code.
- * @param issueArgs - The issue arguments passed from the calling function.
- * @returns The parsed schema XML data.
- * @throws {IssueError} If the schema could not be loaded.
- */
-async function loadSchemaFile(
-  xmlDataPromise: Promise<string>,
-  issueCode: string,
-  issueArgs: IssueParameters,
-): Promise<HedSchemaXMLObject> {
-  try {
-    const data = await xmlDataPromise
-    return parseSchemaXML(data)
-  } catch (error) {
-    IssueError.generateAndRethrow(
-      error,
-      (error) => [issueCode, { ...issueArgs, error: error.message }],
-      'Illegal error type when loading schema file',
-    )
+  /**
+   * Determine whether this validator bundles a particular schema.
+   *
+   * @param schemaDef - The description of which schema to use.
+   * @returns Whether this validator bundles a particular schema.
+   */
+  override hasBundledSchema(schemaDef: SchemaSpec): boolean {
+    return localSchemaMap.has(schemaDef.localName)
   }
 }

--- a/src/schema/loader.ts
+++ b/src/schema/loader.ts
@@ -22,16 +22,6 @@ export default class HedSchemaLoader extends AbstractHedSchemaLoader {
   }
 
   /**
-   * Retrieve the contents of a bundled schema.
-   *
-   * @param schemaDef - The description of which schema to use.
-   * @returns The raw schema XML data.
-   */
-  override async getBundledSchema(schemaDef: SchemaSpec): Promise<string> {
-    return localSchemaMap.get(schemaDef.localName)
-  }
-
-  /**
    * Determine whether this validator bundles a particular schema.
    *
    * @param schemaDef - The description of which schema to use.
@@ -39,5 +29,15 @@ export default class HedSchemaLoader extends AbstractHedSchemaLoader {
    */
   override hasBundledSchema(schemaDef: SchemaSpec): boolean {
     return localSchemaMap.has(schemaDef.localName)
+  }
+
+  /**
+   * Retrieve the contents of a bundled schema.
+   *
+   * @param schemaDef - The description of which schema to use.
+   * @returns The raw schema XML data.
+   */
+  override async getBundledSchema(schemaDef: SchemaSpec): Promise<string> {
+    return localSchemaMap.get(schemaDef.localName)
   }
 }


### PR DESCRIPTION
This PR restructures the schema loading code as a group of three classes (one for local, one for browser, and a shared abstract class containing the bulk of the code).