### PR TITLE
Corrections to the schema parser rewrite backported from hed-javascript

### DIFF
--- a/src/schema/entries/tag.ts
+++ b/src/schema/entries/tag.ts
@@ -162,7 +162,7 @@ export default class SchemaTag extends SchemaEntryWithAttributes {
    *
    * @remarks
    *
-   * Schema tags are deemed equivalent if they have the same name and equivalent attributes, unit and value classes, and parents.
+   * Schema tags are deemed equivalent if they have the same name and equivalent attributes, parent tags, and value tags.
    *
    * @param other - A schema tag to compare with this one.
    * @returns Whether the other tag is equivalent to this schema tag.

--- a/src/schema/entries/valueTag.ts
+++ b/src/schema/entries/valueTag.ts
@@ -76,14 +76,15 @@ export default class SchemaValueTag extends SchemaTag {
   }
 
   /**
-   * Determine if this schema tag is equivalent to another schema tag.
+   * Determine if this schema value tag is equivalent to another schema value tag.
    *
    * @remarks
    *
-   * Schema tags are deemed equivalent if they have the same name and equivalent attributes, unit and value classes, and parents.
+   * Schema value tags are deemed equivalent if they have the same name and equivalent attributes, equivalent unit and
+   * value classes, and parent tags equivalent based on their names and attributes *only*.
    *
-   * @param other - A schema tag to compare with this one.
-   * @returns Whether the other tag is equivalent to this schema tag.
+   * @param other - A schema value tag to compare with this one.
+   * @returns Whether the other value tag is equivalent to this schema value tag.
    */
   public override equivalent(other: unknown): boolean {
     if (!(other instanceof SchemaValueTag)) {

--- a/src/schema/parser/tag.ts
+++ b/src/schema/parser/tag.ts
@@ -239,7 +239,8 @@ export default class TagParser extends SchemaEntryWithAttributesParser<SchemaTag
       for (const childTag of this.getAllChildTags(tagElement)) {
         const childTagName = getElementTagName(childTag)
         const newBooleanAttributes =
-          booleanAttributeDefinitions.get(childTagName)?.union(recursiveAttributes) ?? new Set<SchemaAttribute>()
+          booleanAttributeDefinitions.get(childTagName)?.union(recursiveAttributes) ??
+          new Set<SchemaAttribute>(recursiveAttributes)
         booleanAttributeDefinitions.set(childTagName, newBooleanAttributes)
       }
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "types": ["node"],
+    "declaration": true,
     "strict": true,
     "strictFunctionTypes": false,
     "strictPropertyInitialization": false,


### PR DESCRIPTION
These are fixes developed during the process of merging https://github.com/hed-standard/hed-javascript/pull/766 that need to be copied back over here.