### PR TITLE
Fix tests to reflect changes to testlib partnering

### DIFF
--- a/tests/jsonTestData/schemaBuildTests.data.js
+++ b/tests/jsonTestData/schemaBuildTests.data.js
@@ -155,7 +155,7 @@ export const schemaBuildTestData = [
         testname: 'lazy-partnered-with wrong-standard-build',
         explanation: '["testlib_2.0.0", "8.3.0"] has wrong standard schema',
         schemaVersion: { Name: 'BadLazyPartnered', HEDVersion: ['testlib_2.0.0', '8.3.0'] },
-        schemaError: new IssueError(generateIssue('differentWithStandard', { versions: JSON.stringify(['8.2.0', '8.3.0']) })),
+        schemaError: new IssueError(generateIssue('differentWithStandard', { versions: JSON.stringify(['8.3.0', '8.4.0']) })),
       },
       {
         testname: 'lazy-partnered-with conflicting-tags-build',

--- a/tests/otherTests/schema.spec.js
+++ b/tests/otherTests/schema.spec.js
@@ -381,7 +381,7 @@ describe('HED schemas', () => {
       })
 
       it('should build schemas from comma-separated version strings', async () => {
-        const versionString = '8.2.0, testlib_2.0.0'
+        const versionString = '8.4.0, testlib_2.0.0'
 
         try {
           const schemas = await buildSchemasFromVersion(versionString)
@@ -394,7 +394,7 @@ describe('HED schemas', () => {
       })
 
       it('should build schemas from comma-separated version strings with spaces', async () => {
-        const versionString = '  8.2.0  ,  testlib_2.0.0  '
+        const versionString = '  8.4.0  ,  testlib_2.0.0  '
 
         try {
           const schemas = await buildSchemasFromVersion(versionString)

--- a/tests/schemaData/unmerged/HED_testlib_2.0.0.xml
+++ b/tests/schemaData/unmerged/HED_testlib_2.0.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
-<HED version="2.0.0" library="testlib" withStandard="8.2.0" unmerged="True">
-   <prologue>This schema tests the ordering effects of various combinations of rooted and extension allowed for rooted schemas. It is compatible with testlib version 3.0.0 but not 2.1.0. Violin-subsound1 has different parents.</prologue>
+<HED version="2.0.0" library="testlib" withStandard="8.4.0" unmerged="True">
+   <prologue>This schema tests the ordering effects of various combinations of rooted and extension allowed for rooted schemas. Conflicts: testlib_2.1.0 Piano-subsound1, Piano-subsound2, Piano-subsound3 have different parents.</prologue>
    <schema>
       <node>
          <name>B-nonextension</name>

--- a/tests/schemaData/unmerged/HED_testlib_2.1.0.xml
+++ b/tests/schemaData/unmerged/HED_testlib_2.1.0.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0" ?>
-<HED version="2.1.0" library="testlib" withStandard="8.2.0" unmerged="True">
-   <prologue>This schema is designed to conflict with testlib 2.0.0 and testlib 3.0.0. For version 2.0.0, the conflict is that Violin-subsound2 has different parents in the two schemas. For 3.0.0, Violin_subsound2 takes value in 2.1.0 but not in 3.0.0.</prologue>
+<HED version="2.1.0" library="testlib" withStandard="8.4.0" unmerged="True">
+   <prologue>Conflicts: testlib_2.0.0 Violin-subsound1, Violin-subsound2, Violin-subsound3 have different parents; testlib_2.0.0 piano-subsound2 does not take value; testlib_2.2.0 Piano-subsound2 takes a value with a unit class.</prologue>
    <schema>
       <node>
          <name>BA-nonextension</name>
-         <description>Does not conflict with testlib 2.0.0 or 3.0.0</description>
          <node>
             <name>SubnodeB1A</name>
          </node>
@@ -14,7 +13,7 @@
       </node>
       <node>
          <name>A-nonextension</name>
-         <description>These should not be sorted.  A should be second. Conflicts with testlib 2.0.0.</description>
+         <description>These should not be sorted.  A should be second.</description>
          <node>
             <name>SubnodeA3</name>
          </node>
@@ -41,7 +40,6 @@
       </node>
       <node>
          <name>Piano-sound</name>
-         <description>Conflicts with testlib 3.0.0.</description>
          <attribute>
             <name>rooted</name>
             <value>Instrument-sound</value>
@@ -61,7 +59,6 @@
       </node>
       <node>
          <name>Violin1-sound</name>
-         <description>Conflicts with testlib 2.0.0.</description>
          <attribute>
             <name>rooted</name>
             <value>Instrument-sound</value>

--- a/tests/schemaData/unmerged/HED_testlib_2.2.0.xml
+++ b/tests/schemaData/unmerged/HED_testlib_2.2.0.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" ?>
+<HED version="2.2.0" library="testlib" withStandard="8.4.0" unmerged="True">
+   <prologue>Conflicts: testlib_3.0.0 Piano_subsound2 does not take value; testlib 2.1.0 takes value but no unit class.</prologue>
+   <schema>
+      <node>
+         <name>Piano-sound</name>
+         <attribute>
+            <name>rooted</name>
+            <value>Instrument-sound</value>
+         </attribute>
+         <node>
+            <name>Piano-subsound1</name>
+         </node>
+         <node>
+            <name>Piano-subsound2</name>
+            <node>
+               <name>#</name>
+               <attribute>
+                  <name>unitClass</name>
+                  <value>frequencyUnits</value>
+               </attribute>
+            </node>
+         </node>
+         <node>
+            <name>Piano-subsound2A</name>
+         </node>
+      </node>
+   </schema>
+   <unitClassDefinitions/>
+   <unitModifierDefinitions/>
+   <valueClassDefinitions/>
+   <schemaAttributeDefinitions/>
+   <propertyDefinitions/>
+</HED>

--- a/tests/schemaData/unmerged/HED_testlib_3.0.0.xml
+++ b/tests/schemaData/unmerged/HED_testlib_3.0.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
-<HED version="3.0.0" library="testlib" withStandard="8.2.0" unmerged="True">
-   <prologue>This schema is designed to be lazy partnered with testlib_2.0.0 but conflicts with testlib_2.1.0. Violin_subsound2 takes value in 2.1.0 but not in 3.0.0.</prologue>
+<HED version="3.0.0" library="testlib" withStandard="8.4.0" unmerged="True">
+   <prologue>This schema is designed to be lazy partnered. No conflict with testlib_2.0.0. The testlib_2.1.0 and 2.2.0 conflict: Piano_subsound2 takes value in 2.1.0 and 2.2.0 but not in 3.0.0.</prologue>
    <schema>
       <node>
          <name>E-extensionallowed</name>

--- a/tests/schemaData/unmerged/HED_testlib_4.0.0.xml
+++ b/tests/schemaData/unmerged/HED_testlib_4.0.0.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" ?>
+<HED version="4.0.0" library="testlib" withStandard="8.4.0" unmerged="True">
+   <prologue>This schema is designed to be lazy partnered with prerelease 8.4.0.</prologue>
+   <schema>
+      <node>
+         <name>Test-some</name>
+         <description>Unknown stuff.</description>
+         <node>
+            <name>Unknown1</name>
+            <description>Unknown1 stuff</description>
+         </node>
+      </node>
+      <node>
+         <name>Fruit</name>
+         <description>Fruit stuff.</description>
+         <attribute>
+            <name>rooted</name>
+            <value>Plant</value>
+         </attribute>
+         <node>
+            <name>Apple</name>
+            <description>Apple stuff</description>
+            <attribute>
+               <name>annotation</name>
+               <value>foodonto:has_botanical_name</value>
+            </attribute>
+            <node>
+               <name>Honey-crisp</name>
+               <description>Type of apple</description>
+            </node>
+         </node>
+      </node>
+      <node>
+         <name>Vegetable</name>
+         <description>Vegetable stuff.</description>
+         <attribute>
+            <name>rooted</name>
+            <value>Plant</value>
+         </attribute>
+         <node>
+            <name>Carrot</name>
+            <description>Carrot stuff</description>
+            <attribute>
+               <name>annotation</name>
+               <value>foodonto:has_botanical_name</value>
+            </attribute>
+         </node>
+      </node>
+   </schema>
+   <unitClassDefinitions/>
+   <unitModifierDefinitions/>
+   <valueClassDefinitions/>
+   <schemaAttributeDefinitions/>
+   <propertyDefinitions/>
+   <epilogue>A final section.</epilogue>
+   <schemaSources>
+      <schemaSource>
+         <name>FoodDB</name>
+         <link>https://fooddb.example.org</link>
+         <description>Botanical and nutritional database for fruits and vegetables.</description>
+      </schemaSource>
+   </schemaSources>
+   <schemaPrefixes>
+      <schemaPrefix>
+         <name>foodonto:</name>
+         <namespace>http://purl.obolibrary.org/obo/foodon.owl</namespace>
+         <description>Food Ontology (FOODON)</description>
+      </schemaPrefix>
+   </schemaPrefixes>
+   <externalAnnotations>
+      <externalAnnotation>
+         <name>foodonto:</name>
+         <id>has_botanical_name</id>
+         <iri>http://purl.obolibrary.org/obo/FOODON_00001234</iri>
+         <description>The botanical or scientific name of a food item.</description>
+      </externalAnnotation>
+   </externalAnnotations>
+</HED>


### PR DESCRIPTION
testlib was updated to be partnered with version 8.4.0 of the standard schema. This PR fixes the tests to reflect that.